### PR TITLE
First go at using a free port instead of defaulting to 8050

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ directly on a D-Wave quantum computer's quantum processing unit (QPU).
 
 ## Usage
 
-Run `python app.py` and open http://127.0.0.1:8050/ in your browser.  A
+Run `python app.py`. 
+A URL of the form http://127.0.0.1:***** will be printed in the console. 
+Open in the url in your browser.
 dropdown menu is provided to choose the dataset.
 
 To visualize feature redundancy, first activate the "Show redundancy" check box.

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@
 # visit http://127.0.0.1:8050/ in your web browser.
 
 import json
+import socket
 
 from dash import Dash, html, dcc, Input, Output, State
 from dash.exceptions import PreventUpdate
@@ -307,6 +308,13 @@ def update_score_figure(feature_score_data, data_key):
     return children
 
 
+def find_free_port():
+    with socket.socket() as s:
+        s.bind(('', 0))            # Bind to a free port provided by the host.
+        return s.getsockname()[1]  # Return the port number assigned.
+
+
 if __name__ == '__main__':
     # Set dev_tools_ui=False or debug=False to disable the dev tools UI
-    app.run_server(debug=True, dev_tools_ui=False)
+    port = find_free_port()
+    app.run_server(debug=True, dev_tools_ui=False, port=port)


### PR DESCRIPTION
This PR is meant to address the issue of most of our Dash demos trying to use port 8050.
Instead, the code looks for a free port and uses that.

Two draw backs are that it makes the readme less clear and requires the user to read console output.

Changing the .yaml file should likely be considered as will