### PR TITLE
Bump pinned dash version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dwave-ocean-sdk>=5.3.0
 scikit-learn>=1.1.1
 openml==0.12.2
 pandas>=1.4.2
-dash==2.6.0
+dash==2.7.0


### PR DESCRIPTION
Bump version to avoid a deprecated `flask` call, see [here](https://github.com/plotly/dash/releases/tag/v2.7.0) for details.