### PR TITLE
Scikit-learn dependency fix

### DIFF
--- a/data.py
+++ b/data.py
@@ -23,7 +23,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import cross_val_score
 
 # TODO: temporary fix for circular import issue;
-# remove when dwave-ocean-sdk>0.8 is released
+# remove when dwave-ocean-sdk>8 is released
 import dwave.cloud.client
 
 from dwave.plugins.sklearn import SelectFromQuadraticModel

--- a/data.py
+++ b/data.py
@@ -22,6 +22,10 @@ import openml
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import cross_val_score
 
+# TODO: temporary fix for circular import issue;
+# remove when dwave-ocean-sdk>0.8 is released
+import dwave.cloud.client
+
 from dwave.plugins.sklearn import SelectFromQuadraticModel
 
 


### PR DESCRIPTION
The D-Wave scikit learn plugin causes a circular import error due to the order in which the cloud client is imported. Until a new bugfix release of Ocean is made, this suffices as a workaround.