### PR TITLE
Update xrefs to docs for new URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,40 @@ directly on a D-Wave quantum computer's quantum processing unit (QPU).
 
 ---
 
+## Installation
+
+You can run this example without installation in cloud-based IDEs that support
+the
+[Development Containers specification](https://containers.dev/supporting) (aka
+"devcontainers") such as GitHub Codespaces.
+
+For development environments that do not support `devcontainers`, install
+requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+If you are cloning the repo to your local system, working in a
+[virtual environment](https://docs.python.org/3/library/venv.html) is
+recommended.
+
 ## Usage
 
-Run `python app.py` and open http://127.0.0.1:8050/ in your browser.  A
-dropdown menu is provided to choose the dataset.
+Your development environment should be configured to access the
+[Leap&trade; quantum cloud service](https://docs.dwavequantum.com/en/latest/ocean/sapi_access_basic.html).
+You can see information about supported IDEs and authorizing access to your Leap
+account
+[here](https://docs.dwavequantum.com/en/latest/leap_sapi/dev_env.html).
+
+Run the following terminal command to start the Dash application:
+
+```bash
+python app.py
+```
+
+Access the user interface with your browser at http://127.0.0.1:8050/.
+A dropdown menu is provided to choose the dataset.
 
 To visualize feature redundancy, first activate the "Show redundancy" check box.
 Then hover the mouse over any of the bars.  The colors of all bars will be

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The demo can be used with two different data sets:
 
 ---
 **Note:** This example solves a CQM on a Leap&trade; quantum-classical 
-[hybrid solver](https://docs.ocean.dwavesys.com/en/stable/concepts/hybrid.html). 
+[hybrid solver](https://docs.dwavequantum.com/en/latest/concepts/hybrid.html). 
 The [MIQUBO Method of Feature Selection](https://github.com/dwave-examples/mutual-information-feature-selection) 
 example solves this same problem using a
-[binary quadratic model (BQM)](https://docs.ocean.dwavesys.com/en/stable/concepts/bqm.html)
+[binary quadratic model (BQM)](https://docs.dwavequantum.com/en/latest/concepts/models.html#binary-quadratic-models)
 directly on a D-Wave quantum computer's quantum processing unit (QPU).
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Feature Selection for CQM
 
 This demo showcases feature selection using the constrained quadratic model
-(CQM) solver via 
+(CQM) solver via
 [D-Wave's scikit-learn plug-in](https://github.com/dwavesystems/dwave-scikit-learn-plugin).
 The demo can be used with two different data sets:
 
@@ -22,9 +22,9 @@ The demo can be used with two different data sets:
   illustrates the impact of feature redundancy.
 
 ---
-**Note:** This example solves a CQM on a Leap&trade; quantum-classical 
-[hybrid solver](https://docs.dwavequantum.com/en/latest/concepts/hybrid.html). 
-The [MIQUBO Method of Feature Selection](https://github.com/dwave-examples/mutual-information-feature-selection) 
+**Note:** This example solves a CQM on a Leap&trade; quantum-classical
+[hybrid solver](https://docs.dwavequantum.com/en/latest/concepts/hybrid.html).
+The [MIQUBO Method of Feature Selection](https://github.com/dwave-examples/mutual-information-feature-selection)
 example solves this same problem using a
 [binary quadratic model (BQM)](https://docs.dwavequantum.com/en/latest/concepts/models.html#binary-quadratic-models)
 directly on a D-Wave quantum computer's quantum processing unit (QPU).


### PR DESCRIPTION
These two commits---[one](https://github.com/dwave-examples/feature-selection-cqm/commit/120ccdb036cfb7dea7e600ae3f344160c97e142c) and [two](https://github.com/dwave-examples/feature-selection-cqm/commit/91c297f926a39bbe009fb749c453d7ce3b0c26ba)---have the URL etc updates and is easier to review without the noise of the [middle commit](https://github.com/dwave-examples/feature-selection-cqm/commit/546fd28c2bf2af02e1e4d0b9cbeabfd85fae1dd9).